### PR TITLE
Make encodings abstract, add native_endian/big_endian methods

### DIFF
--- a/src/Encodings.jl
+++ b/src/Encodings.jl
@@ -66,4 +66,5 @@ codeunit{E <: UTF32}(::Type{E})  = UInt32
 
 # size of code unit in bytes
 Base.sizeof{E <: Encoding}(::Type{E}) = sizeof(codeunit(E))
+
 #end


### PR DESCRIPTION
This change allows you do simply deal with the abstract `UTF16`, instead of big-endian vs. little-endian variants (which only is an issue when you have to store them into bytes).
For example, next will return a Char, not a sequence of bytes, so you can write a function that handles UTF16 encoding, and pass it something that is UTF16OE, and it will handle the byte-swapping for you.
